### PR TITLE
build for universal2, not separate arm64/x64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-*"
           CIBW_TEST_SKIP: "*_arm64"
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_MACOS: "universal2"
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Applications that might want to bundle appscript will almost certainly want to be multi-architecture as we are mid-transition to apple silicon; building separate wheels creates artifacts that are architecture-specific and thus will not work in a universal2 application.